### PR TITLE
doc(syntax-mql): Add docstring to syntax files

### DIFF
--- a/Lang/CommonMqlSyntax.mqh
+++ b/Lang/CommonMqlSyntax.mqh
@@ -1,4 +1,6 @@
 /*
+ * NOTE! These syntax files are actually NEVER included in the build: They are only used in
+ *  preprocessor guards and used to provide IDE completions (VSCode, IntelliJ,...).
  */
 // unsupported keyword
 #define input

--- a/Lang/Mql4Syntax.mqh
+++ b/Lang/Mql4Syntax.mqh
@@ -1,5 +1,8 @@
 /*
  * mt4syntax define those not defined in both mt5 or c++
+ *
+ * NOTE! These syntax files are actually NEVER included in the build: They are only used in
+ *  preprocessor guards and used to provide IDE completions (VSCode, IntelliJ,...).
  */
 // anyway common/mql4/5syntax are fake
 #include <stdio.h>


### PR DESCRIPTION
Clarify they are not included in the build.