### PR TITLE
feat(OrderManager): Move magic & expiration, add copy constructor

### DIFF
--- a/Trade/OrderManager.mqh
+++ b/Trade/OrderManager.mqh
@@ -82,6 +82,14 @@ public:
 		m_color[1] = clrRed;
 	}
 
+  // Copy constructor
+	OrderManager(OrderManager& o)
+  	  : s(o.s), MINLOT(o.MINLOT), POINT(o.POINT), STOPLEVEL(o.STOPLEVEL), m_magic(o.m_magic), m_slippage(o.m_slippage)
+	    , m_lastError(o.m_lastError), m_closeColor(o.m_closeColor) {
+	  m_color[0] = o.m_color[0];
+	  m_color[1] = o.m_color[1];
+  }
+
 	static bool IsTradeAllowed(void) {
 		if (!Terminal::isTradeAllowed()) {
 			Alert(">>> Error: please allow EA trading in Terminal settings!");


### PR DESCRIPTION
Order manager instance members:

* In order to enable that every trade can use their own magic number,
  the member fields is moved to method arguments.

  MQL `OrderSend()` allows to specify a magic number on each trade and
  the OrderManager API was lacking the feature, making all trades
  performed under the OrderManager instance use the same magic.

* Add `expiration` to limit (pending) orders API. Same reason above.
  Default to 0, which means no expiration.

Add copy constructor:

* Without it, OrderManager instances cannot be returned from functions.

